### PR TITLE
chore: gPas health check, fetch metadata instead of send invalid gPas…

### DIFF
--- a/src/main/kotlin/dev/dnpm/etl/processor/monitoring/ConnectionCheckService.kt
+++ b/src/main/kotlin/dev/dnpm/etl/processor/monitoring/ConnectionCheckService.kt
@@ -162,11 +162,8 @@ class GPasConnectionCheckService(
     fun check() {
         result = try {
             val uri = UriComponentsBuilder.fromUriString(
-                gPasConfigProperties.uri?.replace("/\$pseudonymizeAllowCreate", "/\$pseudonymize").toString()
-            )
-                .queryParam("target", gPasConfigProperties.target)
-                .queryParam("original", "???")
-                .build().toUri()
+                gPasConfigProperties.uri?.replace("/\$pseudonymizeAllowCreate", "/metadata").toString()
+            ).build().toUri()
 
             val headers = HttpHeaders()
             headers.contentType = MediaType.APPLICATION_JSON


### PR DESCRIPTION
Der aktuelle gPas Health-Check produziert pro Minute einen Fehlereintrag im gPas Log, da ein ungültiges Pseudonym abgefragt wird.

Seitens gPas wird derzeit kein schöner Weg Health-Check über die REST Schnittstelle angeboten. Über die SOAP-Schnittstelle könnte man ggf. die Verfügbarkeit der Ziel Domäne abfragen. 
Anderseits reicht es meiner Meinung nach auch, die FHIR Metadaten von gPas abfragen. Es ist leichtgewichtig, schnell und prüft User sowie Passwort. Es wir keine Fehlermeldung produziert und löst keine unnötige Datenbankabfrage seitens gPas aus.